### PR TITLE
Add includeAllFunctions option to PersonDataSearch & -Find

### DIFF
--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataFind.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataFind.java
@@ -5,6 +5,7 @@ import java.util.List;
 import pnet.data.api.util.AbstractFind;
 import pnet.data.api.util.CompanyMergable;
 import pnet.data.api.util.FindFunction;
+import pnet.data.api.util.IncludeAllFunctions;
 import pnet.data.api.util.IncludeInactive;
 import pnet.data.api.util.Orderable;
 import pnet.data.api.util.Pair;
@@ -55,8 +56,8 @@ public class PersonDataFind extends AbstractFind<PersonItemDTO, PersonDataFind>
     RestrictAdvisorAssignmentCompany<PersonDataFind>, RestrictAdvisorAssignmentType<PersonDataFind>,
     RestrictAdvisorAssignmentDivision<PersonDataFind>, RestrictCredentialsAvailable<PersonDataFind>,
     RestrictApproved<PersonDataFind>, RestrictUpdatedAfter<PersonDataFind>, RestrictDatedBackUntil<PersonDataFind>,
-    IncludeInactive<PersonDataFind>, CompanyMergable<PersonDataFind>, Orderable<PersonDataFind, PersonOrderBy>,
-    Scrollable<PersonDataFind>
+    IncludeInactive<PersonDataFind>, IncludeAllFunctions<PersonDataFind>, CompanyMergable<PersonDataFind>,
+    Orderable<PersonDataFind, PersonOrderBy>, Scrollable<PersonDataFind>
 {
     public PersonDataFind(FindFunction<PersonItemDTO> findFunction, List<Pair<String, Object>> restrictItems)
     {

--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataSearch.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataSearch.java
@@ -8,6 +8,7 @@ import pnet.data.api.util.AggregateNumberPerCompany;
 import pnet.data.api.util.AggregateNumberPerFunction;
 import pnet.data.api.util.AggregateNumberPerTenant;
 import pnet.data.api.util.CompanyMergable;
+import pnet.data.api.util.IncludeAllFunctions;
 import pnet.data.api.util.IncludeInactive;
 import pnet.data.api.util.Pair;
 import pnet.data.api.util.RestrictActivity;
@@ -30,20 +31,19 @@ import pnet.data.api.util.SearchWithAggregationsFunction;
  * @author ham
  */
 public class PersonDataSearch
-    extends AbstractSearchWithAggregations<PersonItemDTO, PersonAggregationsDTO, PersonDataSearch> implements
-    RestrictTenant<PersonDataSearch>, RestrictCompanyId<PersonDataSearch>, RestrictCompanyNumber<PersonDataSearch>,
-    RestrictCompany<PersonDataSearch>, RestrictBrand<PersonDataSearch>, RestrictFunction<PersonDataSearch>,
-    RestrictActivity<PersonDataSearch>, RestrictRole<PersonDataSearch>, RestrictCredentialsAvailable<PersonDataSearch>,
-    RestrictApproved<PersonDataSearch>, RestrictDatedBackUntil<PersonDataSearch>, IncludeInactive<PersonDataSearch>,
+    extends AbstractSearchWithAggregations<PersonItemDTO, PersonAggregationsDTO, PersonDataSearch>
+    implements RestrictTenant<PersonDataSearch>, RestrictCompanyId<PersonDataSearch>,
+    RestrictCompanyNumber<PersonDataSearch>, RestrictCompany<PersonDataSearch>, RestrictBrand<PersonDataSearch>,
+    RestrictFunction<PersonDataSearch>, RestrictActivity<PersonDataSearch>, RestrictRole<PersonDataSearch>,
+    RestrictCredentialsAvailable<PersonDataSearch>, RestrictApproved<PersonDataSearch>,
+    RestrictDatedBackUntil<PersonDataSearch>, IncludeInactive<PersonDataSearch>, IncludeAllFunctions<PersonDataSearch>,
     CompanyMergable<PersonDataSearch>, AggregateNumberPerTenant<PersonDataSearch>,
     AggregateNumberPerCompany<PersonDataSearch>, AggregateNumberPerFunction<PersonDataSearch>,
     AggregateNumberPerActivity<PersonDataSearch>, RestrictQueryField<PersonDataSearch>
 {
-
     public PersonDataSearch(SearchWithAggregationsFunction<PersonItemDTO, PersonAggregationsDTO> searchFunction,
         List<Pair<String, Object>> restrictItems)
     {
         super(searchFunction, restrictItems);
     }
-
 }

--- a/pnet-data-api-java/src/main/java/pnet/data/api/util/IncludeAllFunctions.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/util/IncludeAllFunctions.java
@@ -1,0 +1,15 @@
+package pnet.data.api.util;
+
+/**
+ * When set, the result contains functions that are not main functions as well
+ *
+ * @author scar
+ * @param <SELF> the type of the restrict for chaining
+ */
+public interface IncludeAllFunctions<SELF extends Restrict<SELF>> extends Restrict<SELF>
+{
+    default SELF includeAllFunctions()
+    {
+        return restrict("includeAllFunctions", true);
+    }
+}


### PR DESCRIPTION
It is now possible to optionally mark a PersonDataSearch or -Find to return all functions, not just the main functions.