### PR TITLE
Deprecate PersonAdvisorAssignmentLinkDTO.brandMatchcode

### DIFF
--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonAdvisorAssignmentLinkDTO.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonAdvisorAssignmentLinkDTO.java
@@ -32,7 +32,6 @@ import pnet.data.api.util.WithCompanyId;
 @Schema(description = "Holds an advisor assignment of the person.")
 public class PersonAdvisorAssignmentLinkDTO extends AbstractLinkDTO implements WithCompanyId, WithBrandMatchcode
 {
-
     private static final long serialVersionUID = 4247336068734009775L;
 
     @Schema(description = "The unique id of the company the person is advisor for.")
@@ -44,7 +43,10 @@ public class PersonAdvisorAssignmentLinkDTO extends AbstractLinkDTO implements W
     @Schema(description = "The number of the company the person has/had is advisor for.")
     private final String companyNumber;
 
-    @Schema(description = "The matchcode of the brand where the person is advisor for.")
+    @Schema(description = "The matchcode of the brand where the person is advisor for. "
+        + "NOTE: Deprecated as of PNETREQ-1357. There is no direct correlation between an advisor and a brand, "
+        + "so this field cannot be reliably set. It will be set to 'null' from now on.")
+    @Deprecated(since = "22.01.2024", forRemoval = true)
     private final String brandMatchcode;
 
     @Schema(description = "The matchcode of the advisor division.")
@@ -53,7 +55,7 @@ public class PersonAdvisorAssignmentLinkDTO extends AbstractLinkDTO implements W
     public PersonAdvisorAssignmentLinkDTO(@JsonProperty("tenant") String tenant,
         @JsonProperty("matchcode") String matchcode, @JsonProperty("companyId") Integer companyId,
         @JsonProperty("companyMatchcode") String companyMatchcode, @JsonProperty("companyNumber") String companyNumber,
-        @JsonProperty("brandMatchcode") String brandMatchcode,
+        @JsonProperty("brandMatchcode") @Deprecated(since = "22.01.2024", forRemoval = true) String brandMatchcode,
         @JsonProperty("divisionMatchcode") String divisionMatchcode)
     {
         super(tenant, matchcode);
@@ -80,6 +82,7 @@ public class PersonAdvisorAssignmentLinkDTO extends AbstractLinkDTO implements W
     }
 
     @Override
+    @Deprecated(since = "22.01.2024", forRemoval = true)
     public String getBrandMatchcode()
     {
         return brandMatchcode;


### PR DESCRIPTION
The field `brandMatchcode` cannot be reliably set for a single DTO, as one advisor can have many related brands.
Thus the field is deprecated and will be set to `null` by default.

Part of #PNETREQ-1357