### PR TITLE
Add person restriction "internal"

### DIFF
--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataAutoComplete.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataAutoComplete.java
@@ -15,6 +15,7 @@ import pnet.data.api.util.RestrictCompanyNumber;
 import pnet.data.api.util.RestrictCredentialsAvailable;
 import pnet.data.api.util.RestrictDatedBackUntil;
 import pnet.data.api.util.RestrictFunction;
+import pnet.data.api.util.RestrictInternal;
 import pnet.data.api.util.RestrictPersonType;
 import pnet.data.api.util.RestrictPersonHierarchy;
 import pnet.data.api.util.RestrictTenant;
@@ -29,15 +30,13 @@ public class PersonDataAutoComplete extends AbstractAutoComplete<PersonAutoCompl
     RestrictCompanyId<PersonDataAutoComplete>, RestrictCompanyNumber<PersonDataAutoComplete>,
     RestrictCompany<PersonDataAutoComplete>, RestrictFunction<PersonDataAutoComplete>,
     RestrictActivity<PersonDataAutoComplete>, RestrictPersonHierarchy<PersonDataAutoComplete>,
-    RestrictCredentialsAvailable<PersonDataAutoComplete>, RestrictApproved<PersonDataAutoComplete>,
-    IncludeInactive<PersonDataAutoComplete>, RestrictDatedBackUntil<PersonDataAutoComplete>,
-    CompanyMergable<PersonDataAutoComplete>
+    RestrictCredentialsAvailable<PersonDataAutoComplete>, RestrictInternal<PersonDataAutoComplete>,
+    RestrictApproved<PersonDataAutoComplete>, IncludeInactive<PersonDataAutoComplete>,
+    RestrictDatedBackUntil<PersonDataAutoComplete>, CompanyMergable<PersonDataAutoComplete>
 {
-
     public PersonDataAutoComplete(AutoCompleteFunction<PersonAutoCompleteDTO> autoCompleteFunction,
         List<Pair<String, Object>> restrictItems)
     {
         super(autoCompleteFunction, restrictItems);
     }
-
 }

--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataFind.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataFind.java
@@ -29,6 +29,7 @@ import pnet.data.api.util.RestrictExternalId;
 import pnet.data.api.util.RestrictFunction;
 import pnet.data.api.util.RestrictGuid;
 import pnet.data.api.util.RestrictId;
+import pnet.data.api.util.RestrictInternal;
 import pnet.data.api.util.RestrictNumber;
 import pnet.data.api.util.RestrictNumberType;
 import pnet.data.api.util.RestrictPersonType;
@@ -58,7 +59,7 @@ public class PersonDataFind extends AbstractScrollableFind<PersonItemDTO, Person
     RestrictAdvisorAssignmentCompanyId<PersonDataFind>, RestrictAdvisorAssignmentCompanyNumber<PersonDataFind>,
     RestrictAdvisorAssignmentCompany<PersonDataFind>, RestrictAdvisorAssignmentType<PersonDataFind>,
     RestrictAdvisorAssignmentDivision<PersonDataFind>, RestrictPersonHierarchy<PersonDataFind>,
-    RestrictCredentialsAvailable<PersonDataFind>, RestrictApproved<PersonDataFind>,
+    RestrictCredentialsAvailable<PersonDataFind>, RestrictInternal<PersonDataFind>, RestrictApproved<PersonDataFind>,
     RestrictUpdatedAfter<PersonDataFind>, RestrictDatedBackUntil<PersonDataFind>,
     IncludeInactive<PersonDataFind>, IncludeAllFunctions<PersonDataFind>, CompanyMergable<PersonDataFind>,
     Orderable<PersonDataFind, PersonOrderBy>

--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataGet.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataGet.java
@@ -16,6 +16,7 @@ import pnet.data.api.util.RestrictDatedBackUntil;
 import pnet.data.api.util.RestrictEmail;
 import pnet.data.api.util.RestrictExternalId;
 import pnet.data.api.util.RestrictGuid;
+import pnet.data.api.util.RestrictInternal;
 import pnet.data.api.util.RestrictPersonnelNumber;
 import pnet.data.api.util.RestrictPreferredUserId;
 import pnet.data.api.util.RestrictTenant;
@@ -26,10 +27,9 @@ import pnet.data.api.util.RestrictTenant;
 public class PersonDataGet extends AbstractGet<PersonDataDTO, PersonDataGet>
     implements RestrictTenant<PersonDataGet>, RestrictExternalId<PersonDataGet>, RestrictGuid<PersonDataGet>,
     RestrictPreferredUserId<PersonDataGet>, RestrictEmail<PersonDataGet>, RestrictDatedBackUntil<PersonDataGet>,
-    RestrictPersonnelNumber<PersonDataGet>, RestrictCredentialsAvailable<PersonDataGet>,
+    RestrictPersonnelNumber<PersonDataGet>, RestrictCredentialsAvailable<PersonDataGet>, RestrictInternal<PersonDataGet>,
     RestrictApproved<PersonDataGet>, IncludeInactive<PersonDataGet>, ById<Integer, PersonDataDTO, PersonDataGet>
 {
-
     public PersonDataGet(GetFunction<PersonDataDTO> getFunction, List<Pair<String, Object>> restricts)
     {
         super(getFunction, restricts);

--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataSearch.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataSearch.java
@@ -21,6 +21,7 @@ import pnet.data.api.util.RestrictCompanyNumber;
 import pnet.data.api.util.RestrictCredentialsAvailable;
 import pnet.data.api.util.RestrictDatedBackUntil;
 import pnet.data.api.util.RestrictFunction;
+import pnet.data.api.util.RestrictInternal;
 import pnet.data.api.util.RestrictPersonType;
 import pnet.data.api.util.RestrictQueryField;
 import pnet.data.api.util.RestrictPersonHierarchy;
@@ -40,8 +41,8 @@ public class PersonDataSearch
     RestrictCompanyNumber<PersonDataSearch>, RestrictCompany<PersonDataSearch>, RestrictBrand<PersonDataSearch>,
     RestrictFunction<PersonDataSearch>, RestrictActivity<PersonDataSearch>, RestrictRole<PersonDataSearch>,
     RestrictPersonHierarchy<PersonDataSearch>, RestrictCredentialsAvailable<PersonDataSearch>,
-    RestrictApproved<PersonDataSearch>, RestrictDatedBackUntil<PersonDataSearch>, IncludeInactive<PersonDataSearch>,
-    IncludeAllFunctions<PersonDataSearch>, CompanyMergable<PersonDataSearch>,
+    RestrictInternal<PersonDataSearch>, RestrictApproved<PersonDataSearch>, RestrictDatedBackUntil<PersonDataSearch>,
+    IncludeInactive<PersonDataSearch>, IncludeAllFunctions<PersonDataSearch>, CompanyMergable<PersonDataSearch>,
     AggregateNumberPerTenant<PersonDataSearch>, AggregateNumberPerCompany<PersonDataSearch>,
     AggregateNumberPerFunction<PersonDataSearch>, AggregateNumberPerActivity<PersonDataSearch>,
     RestrictQueryField<PersonDataSearch>

--- a/pnet-data-api-java/src/main/java/pnet/data/api/util/RestrictInternal.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/util/RestrictInternal.java
@@ -1,0 +1,15 @@
+package pnet.data.api.util;
+
+/**
+ * Restricts whether the person is an internal employee or not
+ *
+ * @param <SELF> the type of the restrict for chaining
+ * @author scar
+ */
+public interface RestrictInternal<SELF extends Restrict<SELF>> extends Restrict<SELF>
+{
+    default SELF internal(boolean internal)
+    {
+        return restrict("internal", internal);
+    }
+}


### PR DESCRIPTION
If set to `true`, only internal persons are returned. If set to `false`, only external persons are returned. If omitted, both are returned.

A person is considered "internal" if he has a personnel number assigned.