### PR TITLE
Adjust person descriptions to require SC_PNET_ACCOUNT scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# pnet-data-api 2.11.5
+
+-   Adjust username and credentialsAvailable descriptions in `PersonDataDTO` and `PersonItemDTO` to require SC_PNET_ACCOUNT scope.
+
 # pnet-data-api 2.11.4
 
 -   `PersonDataDTO`, `PersonItemDTO` now have a `isLocked()` getter and a Collection of `PersonLockLinkDTO` to check if the persons login is locked and the reasons why.

--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataDTO.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonDataDTO.java
@@ -75,10 +75,10 @@ public class PersonDataDTO implements WithId, WithPersonId, WithTenants, WithLas
     @Schema(description = "The last name of the person (needed scope: SC_NAME).")
     private String lastName;
 
-    @Schema(description = "The username of the person (needed scope: SC_IDENTIFIER).")
+    @Schema(description = "The username of the person (needed scope: SC_PNET_ACCOUNT).")
     private String username;
 
-    @Schema(description = "The person is able to access the Partner.Net (needed scope: SC_IDENTIFIER).")
+    @Schema(description = "The person is able to access the Partner.Net (needed scope: SC_PNET_ACCOUNT).")
     private Boolean credentialsAvailable;
 
     @Schema(description = "True, if the user has (or had) additional authentication factors enabled.")

--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonItemDTO.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonItemDTO.java
@@ -70,10 +70,10 @@ public class PersonItemDTO implements WithPersonId, WithTenants, WithLastUpdate,
     @Schema(description = "The last name of the person (needed scope: SC_NAME).")
     private final String lastName;
 
-    @Schema(description = "The username of the person (needed scope: SC_IDENTIFIER).")
+    @Schema(description = "The username of the person (needed scope: SC_PNET_ACCOUNT).")
     private final String username;
 
-    @Schema(description = "The username of the person (needed scope: SC_IDENTIFIER).")
+    @Schema(description = "The username of the person (needed scope: SC_PNET_ACCOUNT).")
     private final Boolean credentialsAvailable;
 
     @Schema(description = "True, if the user has (or had) additional authentication factors enabled.")


### PR DESCRIPTION
Username and credentialsAvailable Fields are getting replaced by person locks, the new account scope is provisional solution to only allow access to these fields for applications that still need them.

PNET-6618