### PR TITLE
Deprecate `LanguageLevel`

### DIFF
--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/LanguageLevel.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/LanguageLevel.java
@@ -4,21 +4,31 @@ package pnet.data.api.person;
  * The competence levels according to the common European reference levels.
  *
  * @author HAM
+ * @deprecated since 3.2.5
  */
+@Deprecated(since = "3.2.5", forRemoval = true)
 public enum LanguageLevel {
+    @Deprecated(since = "3.2.5", forRemoval = true)
     UNDEFINED,
 
+    @Deprecated(since = "3.2.5", forRemoval = true)
     A1,
+    @Deprecated(since = "3.2.5", forRemoval = true)
     A2,
 
+    @Deprecated(since = "3.2.5", forRemoval = true)
     B1,
+    @Deprecated(since = "3.2.5", forRemoval = true)
     B2,
 
+    @Deprecated(since = "3.2.5", forRemoval = true)
     C1,
+    @Deprecated(since = "3.2.5", forRemoval = true)
     C2,
 
     /**
      * Used for deserialization of unknown enum values from JSON (see UnknownEnumDeserializationHandler).
      */
+    @Deprecated(since = "3.2.5", forRemoval = true)
     UNKNOWN,
 }

--- a/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonLanguageLinkDTO.java
+++ b/pnet-data-api-java/src/main/java/pnet/data/api/person/PersonLanguageLinkDTO.java
@@ -19,12 +19,13 @@ public class PersonLanguageLinkDTO implements Serializable {
     @Schema(description = "The language as IETF language tag.")
     private final Locale language;
 
-    @Schema(description = "The level of competence.")
+    @Schema(description = "The level of competence. Deprecated since 3.2.5, as it was never populated with any data.")
+    @Deprecated(since = "3.2.5", forRemoval = true)
     private final LanguageLevel level;
 
     public PersonLanguageLinkDTO(
-        @JsonProperty("language") Locale language,
-        @JsonProperty("level") LanguageLevel level
+        @JsonProperty("language") Locale language,        
+        @Deprecated(since = "3.2.5", forRemoval = true) @JsonProperty("level") LanguageLevel level
     ) {
         super();
         this.language = language;
@@ -35,13 +36,14 @@ public class PersonLanguageLinkDTO implements Serializable {
         return language;
     }
 
+    @Deprecated(since = "3.2.5", forRemoval = true)
     public LanguageLevel getLevel() {
         return level;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(language, level);
+        return Objects.hash(language);
     }
 
     @Override
@@ -55,12 +57,6 @@ public class PersonLanguageLinkDTO implements Serializable {
         if (!(obj instanceof PersonLanguageLinkDTO other)) {
             return false;
         }
-        if (!Objects.equals(language, other.language)) {
-            return false;
-        }
-        if (level != other.level) {
-            return false;
-        }
-        return true;
+        return Objects.equals(language, other.language);
     }
 }


### PR DESCRIPTION
The field was never populated with any data and is effectively dead.

Done for PNET-7478